### PR TITLE
Fix grep for literal question mark

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -93,7 +93,7 @@ import() {
 		local tmpheader="$cache_path.header"
 		local locfile="$cache/locations/$url_path"
 		local qs="?"
-		if echo "$url" | grep '\?' > /dev/null; then
+		if echo "$url" | grep '?' > /dev/null; then
 			qs="&"
 		fi
 		local url_with_qs="${url}${qs}format=raw"


### PR DESCRIPTION
For default basic regular expressions (BRE), '?' is literal and '\?' is repetition.

Fixes "grep: bad regex '\?': Repetition not preceded by valid expression" in tests.