### PR TITLE
Honor OS defaults for default cache location

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,7 @@
 `import` is a simple and fast module system for Bash and other Unix shells.
 
 Inspired by Go's import command, you specify the URL of the shell script,
-and the `import` function downloads the file and caches it to `~/.import-cache`,
-_forever_.
+and the `import` function downloads the file and caches it locally, _forever_.
 
 The code will never change from below your feet, and will continue to work
 offline.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,7 +1,7 @@
 ## 💸 Caching
 
 Caching is a core concept in `import`. Scripts are downloaded _exactly once_, and
-then cached on your filesystem _forever_ (or if the `IMPORT_RELOAD=1` environment
+then cached on your filesystem _forever_ (unless the `IMPORT_RELOAD=1` environment
 variable is set).
 
 ```bash
@@ -41,7 +41,7 @@ $ tree /tmp
 ├── data
 │   └── bf671d3752778f91ad0884ff81b3e963af9e4a4f
 ├── links
-│   └── https:
+│   └── https
 │       └── import.pw
 │           └── assert -> ../../../data/bf671d3752778f91ad0884ff81b3e963af9e4a4f
 └── locations
@@ -55,3 +55,10 @@ $ tree /tmp
  * `data` - The raw shell scripts, named after the sha1sum of the file contents
  * `links` - Symbolic links that are named according to the import URL
  * `locations` - Files named according to the import URL that point to the _real_ URL
+
+### ⚙️ Cache Location
+
+If the `$IMPORT_CACHE` environment variable is not set, the cache location defaults to the directory `import.pw` in the OS-specific user cache directory. For this user cache directory `import` considers (in order):
+* `$XDG_CACHE_HOME` ([usually](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) set on Linux)
+* `$LOCALAPPDATA` (usually set on Windows)
+* `$HOME/Library/Caches` on macOS and `$HOME/.cache` everywhere else

--- a/import.sh
+++ b/import.sh
@@ -60,9 +60,11 @@ import() {
 	esac
 
 	# The base directory for the import cache.
-	# Defaults to `$HOME/.import_cache`.
+	# Defaults to `import.pw` in the user cache directory specified by `$XDG_CACHE_HOME` or `$LOCALAPPDATA` (falling back to `$HOME/Library/Caches` on macOS and `$HOME/.cache` everywhere else).
 	# May be configured by setting the `IMPORT_CACHE` variable.
-	local cache="${IMPORT_CACHE-${HOME}/.import-cache}"
+	local ucd_fallback="$HOME/.cache"
+	[ "$(uname -s)" = "Darwin" ] && ucd_fallback="$HOME/Library/Caches"
+	local cache="${IMPORT_CACHE:-${XDG_CACHE_HOME:-${LOCALAPPDATA:-$ucd_fallback}}/import.pw}"
 
 	# Apply the default server if the user is doing an implicit import
 	if ! echo "$url" | grep "://" > /dev/null && ! echo "$url" | awk -F/ '{print $1}' | awk -F@ '{print $1}' | grep '\.' > /dev/null; then


### PR DESCRIPTION
- rename to `import.pw` relative to OS default cache location
- honor $XDG_CACHE_HOME and $LOCALAPPDATA and fall back to "$HOME/.cache"

Note: this fixes the "$HOME folder bloat" mentioned in Issue #36 and follows OS conventions on Linux and Windows as mentioned in https://github.com/importpw/import/issues/36#issuecomment-660370606. For macOS it falls back to `$HOME/.cache` since handling macOS would require uname wrangling which I would prefer to avoid, mostly for #38. On my macOS installation `$HOME/.cache` already exists since it is used by other tools as well so it is a compromise I personally could live with.

Additionally, it renames the directory to `import.pw` to be easier to google.

Please let me know if you would prefer a different approach.