### PR TITLE
Add `import_file` function to separate download from sourcing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,3 +13,15 @@ import "https://import.pw/string@0.2.0"
 echo InPuT | string_upper
 # INPUT
 ```
+
+### `import_file "$url"`
+
+The `import_file` functions uses the same download & cache infrastructure as
+`import` but prints the local path instead of sourcing the file. This supports
+working with arbitrary files including scripts in other languages and simple
+data files.
+```bash
+#!/usr/bin/env import
+ruby "$(import_file https://import.pw/importpw/import/test/static/sum.rb)" 9 10 11 12
+# 42
+```

--- a/import.sh
+++ b/import.sh
@@ -162,6 +162,9 @@ import() {
 	fi
 }
 
+import_file() {
+	print=1 import "$@"
+}
 
 # For `#!/usr/bin/env import`
 if [ -n "${ZSH_EVAL_CONTEXT-}" ]; then

--- a/test/static/sum.rb
+++ b/test/static/sum.rb
@@ -1,0 +1,1 @@
+puts ARGV.map(&:to_i).sum

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,7 +16,7 @@ finish() {
 }
 trap finish EXIT INT QUIT
 
-IMPORT_CACHE=cache
+IMPORT_CACHE="$PWD/cache"
 IMPORT_DEBUG=1
 IMPORT_RELOAD=1
 IMPORT_SERVER="${nginx_addr}"
@@ -49,6 +49,16 @@ test "$(subdir_rel)" = "subdir_rel"
 # Test multiple words
 import pkg as foo
 test "$(foo)" = "this is foo"
+
+# Test import_file
+sum_rb_path="$(import_file "$nginx_addr/sum.rb")"
+test "$sum_rb_path" = "$IMPORT_CACHE/links/http/127.0.0.1:12006/sum.rb"
+diff -q "$sum_rb_path" "test/static/sum.rb"
+
+# Test import with print=1 (equivalent to import_file; supported for backwards compatibility)
+sum_rb_path="$(print=1 import "$nginx_addr/sum.rb")"
+test "$sum_rb_path" = "$IMPORT_CACHE/links/http/127.0.0.1:12006/sum.rb"
+diff -q "$sum_rb_path" "test/static/sum.rb"
 
 
 echo "Tests passed!"


### PR DESCRIPTION
I first tried to have `import_file` as a separate function that is used by `import`, but sourcing requires access to a couple of other local variables. Therefore, this basically just makes the `print=1` trick explicit, as you proposed.